### PR TITLE
Add extension functions for dependencies

### DIFF
--- a/src/main/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePlugin.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePlugin.groovy
@@ -3,10 +3,9 @@ package ru.endlesscode.bukkitgradle
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.DependencyResolutionListener
-import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.compile.JavaCompile
+import ru.endlesscode.bukkitgradle.util.Dependencies
 
 class BukkitGradlePlugin implements Plugin<Project> {
     final static String GROUP = 'Bukkit'
@@ -87,30 +86,6 @@ class BukkitGradlePlugin implements Plugin<Project> {
      * Adds needed dependencies
      */
     void addDependencies() {
-        project.gradle.addListener(new DependencyResolutionListener() {
-            @Override
-            void beforeResolve(ResolvableDependencies resolvableDependencies) {
-                addBukkitApi(project)
-                project.gradle.removeListener(this)
-            }
-
-            @Override
-            void afterResolve(ResolvableDependencies resolvableDependencies) {}
-        })
-    }
-
-    /**
-     * Adds Bukkit API to project dependencies
-     * @param project The project
-     */
-    static void addBukkitApi(Project project) {
-        project.with {
-            def compileOnlyDeps = configurations.compileOnly.dependencies
-            def testCompileDeps = configurations.testCompile.dependencies
-            def bukkitDep = dependencies.create("org.bukkit:bukkit:$bukkit.version")
-
-            compileOnlyDeps.add(bukkitDep)
-            testCompileDeps.add(bukkitDep)
-        }
+        Dependencies.configureProject(project)
     }
 }

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
@@ -6,14 +6,14 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 
 class Dependencies {
 
+    private static Project project
     private static DependencyHandler handler
-    private static String version
 
     private Dependencies() {}
 
     static configureProject(Project project) {
+        this.project = project
         handler = project.dependencies
-        version = project.bukkit.version
         addExtensions()
     }
 
@@ -27,6 +27,7 @@ class Dependencies {
     }
 
     private static Dependency api(String groupId, String artifactId) {
+        def version = project.bukkit.version
         return handler.create("$groupId:$artifactId:$version")
     }
 }

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
@@ -1,0 +1,32 @@
+package ru.endlesscode.bukkitgradle.util
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+class Dependencies {
+
+    private static DependencyHandler handler
+    private static String version
+
+    private Dependencies() {}
+
+    static configureProject(Project project) {
+        handler = project.dependencies
+        version = project.bukkit.version
+        addExtensions()
+    }
+
+    private static addExtensions() {
+        handler.ext {
+            spigot = { api('org.spigotmc', 'spigot') }
+            spigotApi = { api('org.spigotmc', 'spigot-api') }
+            bukkit = { api('org.bukkit', 'bukkit') }
+            craftbukkit = { api('org.bukkit', 'craftbukkit') }
+        }
+    }
+
+    private static Dependency api(String groupId, String artifactId) {
+        return handler.create("$groupId:$artifactId:$version")
+    }
+}

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/MavenApi.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/MavenApi.groovy
@@ -24,7 +24,7 @@ class MavenApi {
                 hasArtifact(groupId, 'spigot', version)
     }
 
-    static def hasArtifact(groupId, artifactId, version) {
+    static def hasArtifact(String groupId, String artifactId, String version) {
         def artifactDir = getArtifactDir(groupId, artifactId, version)
         return Files.exists(artifactDir)
     }
@@ -33,7 +33,7 @@ class MavenApi {
         return getArtifactDir('org.spigotmc', 'spigot', version)
     }
 
-    static def getArtifactDir(groupId, artifactId, version) {
+    static def getArtifactDir(String groupId, String artifactId, String version) {
         return mavenLocal.resolve("${groupId.replace('.', '/')}/$artifactId/$version/")
     }
 }

--- a/src/test/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePluginTest.groovy
+++ b/src/test/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePluginTest.groovy
@@ -3,6 +3,7 @@ package ru.endlesscode.bukkitgradle
 import org.gradle.api.artifacts.Dependency
 import org.junit.Test
 
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
 
 class BukkitGradlePluginTest extends TestBase {
@@ -20,18 +21,21 @@ class BukkitGradlePluginTest extends TestBase {
 
     @Test
     void testPluginAddsLatestBukkitVersion() throws Exception {
-        BukkitGradlePlugin.addBukkitApi(project)
-        def dependencies = getDependencies()
-        assertTrue dependencies.contains("org.bukkit:bukkit:+")
+
+        Dependency dependency = project.dependencies.ext.bukkit()
+        assertEquals('org.bukkit', dependency.group)
+        assertEquals('bukkit', dependency.name)
+        assertEquals('+', dependency.version)
     }
 
     @Test
     void testPluginAddsCustomBukkit() throws Exception {
         project.bukkit.version = "1.7.10"
-        BukkitGradlePlugin.addBukkitApi(project)
 
-        def dependencies = getDependencies()
-        assertTrue dependencies.contains("org.bukkit:bukkit:1.7.10-R0.1-SNAPSHOT")
+        Dependency dependency = project.dependencies.ext.bukkit()
+        assertEquals('org.bukkit', dependency.group)
+        assertEquals('bukkit', dependency.name)
+        assertEquals('1.7.10-R0.1-SNAPSHOT', dependency.version)
     }
 
     private String[] getDependencies() {


### PR DESCRIPTION
Now you should manually add api dependencies.
Possible APIs:
```groovy
dependencies {
    compileOnly spigot()
    compileOnly spigotApi()
    compileOnly bukkit()
    compileOnly craftbukkit()
}
```

Relates to #4 