### PR TITLE
Local properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,21 @@ Also you can add custom (unsupported by BukkitGradle) attributes like a `depend`
 Just create `plugin.yml` file and put custom attributes into.
 
 ### Running Dev server
-Before running server you should configure path to BuildTools:
-```groovy
-bukkit {
-    buildtools = '/path/to/BuildTools.jar' // It can be only local directory
-}
+Before running server you should configure BuildTools and dev server location.
+
+You can define it in `local.properties` file (that was automatically created in project root on refresh):
+```properties
+# Absolute path to directory that contains BuildTools.jar
+buildtools.dir=/path/to/buildtools/
+# Absolute path to dev server
+server.dir=/path/to/buildtools/
 ```
+Or you can define it globally (for all projects that uses BukkitGradle) with environment variables `BUKKIT_DEV_SERVER_HOME` 
+and `BUILDTOOLS_HOME`.
 
 ##### On IntelliJ IDEA
-Run `:buildIdeaRun` task. To your IDE will be added Run Configuration that will dynamically refreshes when you change server configurations.
+Run `:buildIdeaRun` task. To your IDE will be added Run Configuration that will dynamically refreshes when you change 
+server configurations.
 
 ![Run Configuration](http://image.prntscr.com/image/1a12a03b8ac54fccb7d5b70a335fa996.png)
 
@@ -138,8 +144,6 @@ bukkit {
        eula = false
        // Set online-mode flag
        onlineMode = false
-       // Path to deploy server (relative)
-       dir = "server"
        // Debug mode (listen 5005 port, if you use running from IDEA this option will be ignored)
        debug = true
        // Set server encoding (flag -Dfile.encoding)

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/extension/Bukkit.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/extension/Bukkit.groovy
@@ -11,7 +11,6 @@ class Bukkit {
     private final Project project
 
     String version
-    String buildtools = ''
 
     final PluginMeta meta
     final RunConfiguration run

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/extension/RunConfiguration.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/extension/RunConfiguration.groovy
@@ -18,7 +18,6 @@ class RunConfiguration {
     boolean onlineMode
     boolean debug
     String encoding
-    String dir
     String javaArgs
     String bukkitArgs
 
@@ -29,7 +28,6 @@ class RunConfiguration {
         this.onlineMode = false
         this.debug = true
         this.encoding = 'UTF-8'
-        this.dir = 'server'
 
         this.javaArgs = '-Xmx1G'
         this.bukkitArgs = ''
@@ -51,15 +49,6 @@ class RunConfiguration {
      */
     String getBukkitArgs() {
         return bukkitArgs ?: ''
-    }
-
-    /**
-     * Returns servers dir
-     *
-     * @return The directory
-     */
-    Path getDir() {
-        project.projectDir.toPath().resolve(this.dir)
     }
 
     /**

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/meta/MetaFile.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/meta/MetaFile.groovy
@@ -76,7 +76,7 @@ class MetaFile {
      */
     private void filterMetaLines() {
         staticLines.clear()
-        if (!Files.exists(metaFile)) {
+        if (Files.notExists(metaFile)) {
             return
         }
 

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/server/SystemScript.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/server/SystemScript.groovy
@@ -22,7 +22,7 @@ abstract class SystemScript {
      */
     void buildOn(Path dir) {
         Path scriptFile = dir.resolve(getFileName())
-        if (!Files.exists(scriptFile)) {
+        if (Files.notExists(scriptFile)) {
             Files.createFile(scriptFile)
         }
 

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/task/PrepareServer.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/task/PrepareServer.groovy
@@ -33,7 +33,7 @@ class PrepareServer extends DefaultTask {
 
     void resolveEula() {
         Path eulaFile = getServerDir().resolve("eula.txt")
-        if (!Files.exists(eulaFile)) {
+        if (Files.notExists(eulaFile)) {
             Files.createFile(eulaFile)
         }
 
@@ -45,7 +45,7 @@ class PrepareServer extends DefaultTask {
 
     void resolveOnlineMode() {
         Path propsFile = getServerDir().resolve("server.properties")
-        if (!Files.exists(propsFile)) {
+        if (Files.notExists(propsFile)) {
             Files.createFile(propsFile)
         }
 

--- a/src/test/groovy/ru/endlesscode/bukkitgradle/TestBase.groovy
+++ b/src/test/groovy/ru/endlesscode/bukkitgradle/TestBase.groovy
@@ -27,10 +27,6 @@ class TestBase {
             description = "Test project description"
             version = "1.0"
             ext.url = "https://www.example.ru/"
-
-            bukkit {
-                buildtools = "/path/to/buildtools"
-            }
         }
     }
 
@@ -78,7 +74,6 @@ command:
             eula = true
             onlineMode = true
             debug = false
-            dir = 'devServer'
             encoding = 'CP866'
             javaArgs = '-Xmx2G'
             bukkitArgs = '-s 2'


### PR DESCRIPTION
Properties `bukkit.buildtools` and `bukkit.run.dir` was removed.

Now you can define it in `local.properties` file (that was automatically created in project root on refresh):
```properties
# Absolute path to directory that contains BuildTools.jar
buildtools.dir=/path/to/buildtools/
# Absolute path to dev server
server.dir=/path/to/buildtools/
 ```
Or you can define it globally (for all projects that uses BukkitGradle) with environment variables 
`BUKKIT_DEV_SERVER_HOME` and `BUILDTOOLS_HOME`.