### PR TITLE
Paper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ needed.
 # Absolute path to directory that contains BuildTools.jar
 buildtools.dir=/path/to/buildtools/
 ```
+If there no BuildTools.jar it will be automatically downloaded.
 
 **TIP:** you can define it globally (for all projects that uses BukkitGradle) with environment variables `BUKKIT_DEV_SERVER_HOME` 
 and `BUILDTOOLS_HOME`.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ group "com.example"
 description "My first Bukkit plugin with Gradle"
 version "0.1"
 
+// Wee need to add some repos
+repositories {
+    spigot()
+    // see section 'Repositories' for more info
+}
+
 // Let's add needed API to project
 dependencies {
     compileOnly bukkit() 
-    // You also can use craftbukkit(), spigot() and spigotApi()
+    // see section 'Dependencies' for more info
 }
 ```
 `compileOnly` - it's like provided scope in Maven. It means that this dependncy will not included to your final jar.
@@ -84,7 +90,7 @@ You can configure attributes that will be placed to `plugin.yml`:
 ```groovy
 // Override default configurations
 bukkit {
-    // Version of API (latest by default)
+    // Version of API (if you will not set this property, will be used latest available)
     version = "1.12.2"
  
     // Attributes for plugin.yml
@@ -112,17 +118,44 @@ authors: [OsipXD, Contributors]
 Also you can add custom (unsupported by BukkitGradle) attributes like a `depend` etc.
 Just create `plugin.yml` file and put custom attributes into.
 
-### Running Dev server
-Before running server you should configure BuildTools and dev server location.
+#### Quotes around values
+In some cases you may need put meta value in quotes. For this you can use `q` and `qq` functions.
 
-You can define it in `local.properties` file (that was automatically created in project root on refresh):
+For example we have meta:
+```groovy
+meta {
+    name = qq "Double Quoted Name"
+    description = q "Single quoted description"
+    url = "http://without.quot.es/"
+}
+```
+
+And will be generated:
+```yaml
+name: "Double Quoted Name"
+description: 'Single quoted description'
+website: http://without.quot.es/
+```
+
+**Note:** In Groovy you can use functions in two ways: normal - `q("value")` and without braces - `q "value"`
+
+### Running Dev server
+Before running server you should configure dev server location.
+
+You can define it in `local.properties` file (that was automatically created in project directory on refresh):
 ```properties
-# Absolute path to directory that contains BuildTools.jar
-buildtools.dir=/path/to/buildtools/
 # Absolute path to dev server
 server.dir=/path/to/buildtools/
 ```
-Or you can define it globally (for all projects that uses BukkitGradle) with environment variables `BUKKIT_DEV_SERVER_HOME` 
+
+If you use Spigot (see `bukkit.run.core`) you also should specify BuildTools location. For Paper no additional actions 
+needed.
+```properties
+# Absolute path to directory that contains BuildTools.jar
+buildtools.dir=/path/to/buildtools/
+```
+
+**TIP:** you can define it globally (for all projects that uses BukkitGradle) with environment variables `BUKKIT_DEV_SERVER_HOME` 
 and `BUILDTOOLS_HOME`.
 
 ##### On IntelliJ IDEA
@@ -132,7 +165,7 @@ server configurations.
 ![Run Configuration](http://image.prntscr.com/image/1a12a03b8ac54fccb7d5b70a335fa996.png)
 
 ##### On other IDEs
-Run ':startServer' task.
+Run `:startServer` task.
 
 #### Server run configurations
 To accept EULA and change settings use `bukkit.run` section:
@@ -140,18 +173,20 @@ To accept EULA and change settings use `bukkit.run` section:
 bukkit {
     // INFO: Here used default values
     run {
-       // Accept EULA
-       eula = false
-       // Set online-mode flag
-       onlineMode = false
-       // Debug mode (listen 5005 port, if you use running from IDEA this option will be ignored)
-       debug = true
-       // Set server encoding (flag -Dfile.encoding)
-       encoding = "UTF-8"
-       // JVM arguments
-       javaArgs = "-Xmx1G"
-       // Bukkit arguments
-       bukkitArgs = ""
+        // Core type. It can be 'spigot' or 'paper'
+        core = "spigot"
+        // Accept EULA
+        eula = false
+        // Set online-mode flag
+        onlineMode = false
+        // Debug mode (listen 5005 port, if you use running from IDEA this option will be ignored)
+        debug = true
+        // Set server encoding (flag -Dfile.encoding)
+        encoding = "UTF-8"
+        // JVM arguments
+        javaArgs = "-Xmx1G"
+        // Bukkit arguments
+        bukkitArgs = ""
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ Gradle utilities for easier writing Bukkit plugins.
 2. [Usage](#usage)
     1. [First steps](#first-steps)
     2. [Configuring plugin](#configuring-plugin)
-    3. [Running Dev server](#running-dev-server)
+        1. [Quotes around values](#quotes-around-values)
+    3. [Repositories and Dependencies](#repositories-and-dependencies)
+    4. [Running Dev server](#running-dev-server)
         1. [Server run configurations](#server-run-configurations)
 
 #### Features:
 - Automatically applies plugins: java, idea, eclipse
 - Sets up compiler encoding to UTF-8
-- Adds repositories: mavenCentral, mavenLocal, spigot-repo, sk89q-repo
-- Provides short extension-functions to include bukkit/craftbukkit/spigot/spigot-api
+- Provides short extension-functions to add common repositories and dependencies
 - Generates plugin.yml from Gradle project information
 - Allows to run dev server from IDE
 - Automatically copies your plugin to plugins dir on server running
@@ -138,6 +139,32 @@ website: http://without.quot.es/
 ```
 
 **Note:** In Groovy you can use functions in two ways: normal - `q("value")` and without braces - `q "value"`
+
+### Repositories and Dependencies
+BukkitGradle provides short extension-functions to add common repositories and dependencies.
+There are list of its.
+
+##### Repositories:
+ Name           | Url
+----------------|----------------------------------------------------------------
+ spigot         | https://hub.spigotmc.org/nexus/content/repositories/snapshots/   
+ sk98q          | http://maven.sk89q.com/repo/                                     
+ destroystokyo  | https://repo.destroystokyo.com/repository/maven-public/ 
+ dmulloy2       | http://repo.dmulloy2.net/nexus/repository/public/
+ md5            | http://repo.md-5.net/content/groups/public/
+ vault          | http://nexus.hc.to/content/repositories/pub_releases/
+ placeholderapi | http://repo.extendedclip.com/content/repositories/placeholderapi/
+
+##### Dependencies:
+ Name        | Signature
+-------------|-----------------------------------------------
+ spigot      | org.spigotmc:spigot:$apiVersion
+ spigotApi   | org.spigotmc:spigot-api:$apiVersion
+ bukkit      | org.bukkit:bukkit:$apiVersion
+ craftbukkit | org.bukkit:craftbukkit:$apiVersion
+ paperApi    | com.destroystokyo.paper:paper-api:$apiVersion
+ 
+ **Note:** `$apiVersion` - is `${version}-R0.1-SNAPSHOT` (where `$version` is `bukkit.version`)
 
 ### Running Dev server
 Before running server you should configure dev server location.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ website: http://without.quot.es/
 BukkitGradle provides short extension-functions to add common repositories and dependencies.
 There are list of its.
 
+Usage example:
+```groovy
+repositories {
+    spigot() // Adds spigot repo
+}
+
+dependencies {
+    compileOnly paperApi() // Adds paper-api dependency
+}
+```
+
 ##### Repositories:
  Name           | Url
 ----------------|----------------------------------------------------------------
@@ -165,6 +176,7 @@ There are list of its.
  paperApi    | com.destroystokyo.paper:paper-api:$apiVersion
  
  **Note:** `$apiVersion` - is `${version}-R0.1-SNAPSHOT` (where `$version` is `bukkit.version`)
+
 
 ### Running Dev server
 Before running server you should configure dev server location.

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePlugin.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePlugin.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.compile.JavaCompile
 import ru.endlesscode.bukkitgradle.util.Dependencies
+import ru.endlesscode.bukkitgradle.util.Repositories
 
 class BukkitGradlePlugin implements Plugin<Project> {
     final static String GROUP = 'Bukkit'
@@ -64,21 +65,11 @@ class BukkitGradlePlugin implements Plugin<Project> {
      * Adds needed repositories
      */
     void addRepositories() {
-        project.with {
-            repositories {
-                mavenLocal()
-                mavenCentral()
+        Repositories.configureProject(project)
 
-                maven {
-                    name = 'sk89q'
-                    url = 'http://maven.sk89q.com/repo/'
-                }
-
-                maven {
-                    name = 'spigot'
-                    url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
-                }
-            }
+        project.repositories {
+            mavenLocal()
+            mavenCentral()
         }
     }
 

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
@@ -1,8 +1,8 @@
 package ru.endlesscode.bukkitgradle
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.internal.impldep.org.apache.maven.lifecycle.LifecycleExecutionException
 import ru.endlesscode.bukkitgradle.server.ServerCore
 import ru.endlesscode.bukkitgradle.task.PrepareServer
 import ru.endlesscode.bukkitgradle.task.RunServer
@@ -33,13 +33,13 @@ class DevServerPlugin implements Plugin<Project> {
             core serverCore
         } as PrepareServer
 
-        Path runConfigurationsDir = project.projectDir.toPath().resolve(".idea/runConfigurations")
+        Path runConfigurationsDir = project.rootProject.projectDir.toPath().resolve(".idea/runConfigurations")
         project.task('buildIdeaRun', dependsOn: 'prepareServer') {
             group = BukkitGradlePlugin.GROUP
             description = 'Configure IDEA server run configuration'
         }.doLast {
             if (Files.notExists(runConfigurationsDir.parent)) {
-                throw new LifecycleExecutionException("This task only for IntelliJ IDEA.")
+                throw new GradleException("This task only for IntelliJ IDEA.")
             }
 
             Files.createDirectories(runConfigurationsDir)

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
@@ -26,7 +26,7 @@ class DevServerPlugin implements Plugin<Project> {
         PrepareServer prepareServer = project.task(
                 'prepareServer',
                 type: PrepareServer,
-                dependsOn: ['build', 'copyServerCore', 'downloadPaperclip']
+                dependsOn: ['build', 'copyServerCore']
         ) {
             group = BukkitGradlePlugin.GROUP
             description = 'Prepare server ro run. Configure server and copy compiled plugin to plugins dir'

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/DevServerPlugin.groovy
@@ -26,7 +26,7 @@ class DevServerPlugin implements Plugin<Project> {
         PrepareServer prepareServer = project.task(
                 'prepareServer',
                 type: PrepareServer,
-                dependsOn: ['build', 'buildServerCore', 'copyServerCore']
+                dependsOn: ['build', 'copyServerCore', 'downloadPaperclip']
         ) {
             group = BukkitGradlePlugin.GROUP
             description = 'Prepare server ro run. Configure server and copy compiled plugin to plugins dir'

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/extension/RunConfiguration.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/extension/RunConfiguration.groovy
@@ -2,6 +2,7 @@ package ru.endlesscode.bukkitgradle.extension
 
 import groovy.xml.MarkupBuilder
 import org.gradle.api.Project
+import ru.endlesscode.bukkitgradle.server.CoreType
 import ru.endlesscode.bukkitgradle.server.ServerCore
 import ru.endlesscode.bukkitgradle.task.PrepareServer
 
@@ -21,8 +22,12 @@ class RunConfiguration {
     String javaArgs
     String bukkitArgs
 
+    private CoreType coreType
+
     RunConfiguration(Project project) {
         this.project = project
+
+        this.coreType = CoreType.SPIGOT
 
         this.eula = false
         this.onlineMode = false
@@ -31,6 +36,20 @@ class RunConfiguration {
 
         this.javaArgs = '-Xmx1G'
         this.bukkitArgs = ''
+    }
+
+    void setCore(String core) {
+        try {
+            coreType = CoreType.valueOf(core.toUpperCase())
+        } catch (IllegalArgumentException ignored) {
+            project.logger.warn("Core type '$core' not found. May be it doesn't supported by BukkitGradle yet. " +
+                    "You may write issue on GitHub to request supporting.\n" +
+                    "Fallback core type is '${coreType.toString().toLowerCase()}'")
+        }
+    }
+
+    def getCoreType() {
+        return coreType
     }
 
     /**

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/server/CoreType.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/server/CoreType.groovy
@@ -1,0 +1,5 @@
+package ru.endlesscode.bukkitgradle.server
+
+enum CoreType {
+    SPIGOT, PAPER
+}

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/Dependencies.groovy
@@ -23,6 +23,7 @@ class Dependencies {
             spigotApi = { api('org.spigotmc', 'spigot-api') }
             bukkit = { api('org.bukkit', 'bukkit') }
             craftbukkit = { api('org.bukkit', 'craftbukkit') }
+            paperApi = { api('com.destroystokyo.paper', 'paper-api') }
         }
     }
 

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/Repositories.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/Repositories.groovy
@@ -1,0 +1,32 @@
+package ru.endlesscode.bukkitgradle.util
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+class Repositories {
+    private static Project project
+    private static RepositoryHandler handler
+
+    private Repositories() {}
+
+    static configureProject(Project project) {
+        this.project = project
+        handler = project.repositories
+        addExtensions()
+    }
+
+    private static addExtensions() {
+        handler.ext {
+            spigot = { addRepo('spigot-repo', 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/') }
+            sk89q = { addRepo('sk89q-repo', 'http://maven.sk89q.com/repo/') }
+            destroystokyo = { addRepo('destroystokyo-repo', 'https://repo.destroystokyo.com/repository/maven-public/') }
+        }
+    }
+
+    private static addRepo(repoName, repoUrl) {
+        handler.maven {
+            name = repoName
+            url = repoUrl
+        }
+    }
+}

--- a/src/main/groovy/ru/endlesscode/bukkitgradle/util/Repositories.groovy
+++ b/src/main/groovy/ru/endlesscode/bukkitgradle/util/Repositories.groovy
@@ -17,9 +17,27 @@ class Repositories {
 
     private static addExtensions() {
         handler.ext {
-            spigot = { addRepo('spigot-repo', 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/') }
-            sk89q = { addRepo('sk89q-repo', 'http://maven.sk89q.com/repo/') }
-            destroystokyo = { addRepo('destroystokyo-repo', 'https://repo.destroystokyo.com/repository/maven-public/') }
+            spigot = {
+                addRepo('spigot-repo', 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/')
+            }
+            sk89q = {
+                addRepo('sk89q-repo', 'http://maven.sk89q.com/repo/')
+            }
+            destroystokyo = {
+                addRepo('destroystokyo-repo', 'https://repo.destroystokyo.com/repository/maven-public/')
+            }
+            dmulloy2 = {
+                addRepo('dmulloy2-repo', 'http://repo.dmulloy2.net/nexus/repository/public/')
+            }
+            md5 = {
+                addRepo('md5-repo', 'http://repo.md-5.net/content/groups/public/')
+            }
+            vault = {
+                addRepo('vault-repo', 'http://nexus.hc.to/content/repositories/pub_releases/')
+            }
+            placeholderapi = {
+                addRepo('placeholderapi-repo', 'http://repo.extendedclip.com/content/repositories/placeholderapi/')
+            }
         }
     }
 

--- a/src/test/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePluginTest.groovy
+++ b/src/test/groovy/ru/endlesscode/bukkitgradle/BukkitGradlePluginTest.groovy
@@ -16,7 +16,11 @@ class BukkitGradlePluginTest extends TestBase {
 
     @Test
     void testPluginAddsRequiredRepos() throws Exception {
-        project.repositories.getByName("spigot")
+        project.repositories {
+            spigot()
+        }
+
+        project.repositories.getByName("spigot-repo")
     }
 
     @Test


### PR DESCRIPTION
### Paper
Now you can choose `bukkit.run.core`. It can be `spigot` or `paper`.
Also added task `:downloadPaperclip` to download paperclip (wow! unexpected).
To host paper versions build was created [this gist](https://gist.github.com/OsipXD/d9ef7020a86e69c13120fa942df8f045).
Added function `paperApi()` to include Paper as dependency.

### Repositories
Repositories was moved to extension functions: [spigot](https://hub.spigotmc.org/nexus/content/repositories/snapshots/), [sk98q](http://maven.sk89q.com/repo/), [destroystokyo](https://repo.destroystokyo.com/repository/maven-public/), [dmulloy2](http://repo.dmulloy2.net/nexus/repository/public/), [md5](http://repo.md-5.net/content/groups/public/), [vault](http://nexus.hc.to/content/repositories/pub_releases/), [placeholderapi](http://repo.extendedclip.com/content/repositories/placeholderapi/).

For example. To add `dmulloy2` repo you should write:
```groovy
repositories {
    dmulloy2()
}
```

#### Checklist:
- [x] Have you read text of project license?
- [x] Have you described maked changes in README or wiki?
- [x] Have you added changelog?
