### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+*No changes yet*
+
+## [1.0.0] - 2025-04-18
+
 ### Pivot!
 
 After a 4-year hiatus in releases, the plugin landscape has evolved significantly.
@@ -211,7 +215,8 @@ now it is friendly to Kotlin DSL.
 [uptodate]: https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks
 [vault]: https://github.com/MilkBowl/VaultAPI
 
-[unreleased]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/0.10.1...develop
+[unreleased]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/1.0.0...develop
+[1.0.0]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/0.10.1...1.0.0
 [0.10.1]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/0.10.0...0.10.1
 [0.10.0]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/0.9.2...0.10.0
 [0.9.2]: https://github.com/EndlessCodeGroup/BukkitGradle/compare/0.9.1...0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,36 @@
 ## [Unreleased]
 
-### Added
+### Pivot!
 
-- Support setting "api-version" containing a patch version for v1.20.5+
-- Add dependency substitution rules fixing paper groupId and substituting bukkit version.
-  In version catalogs placeholder value `{bukkit.version}` can be used, and it will be replaced with the actual version:
-  ```toml
-  [libraries]
-  paperApi = { module = "io.papermc.paper:paper-api", version = "{bukkit.apiVersion}" }
-  ```
+After a 4-year hiatus in releases, the plugin landscape has evolved significantly.
+jpenilla's excellent plugins [run-task](https://github.com/jpenilla/run-task/) and [resource-factory](https://github.com/jpenilla/resource-factory) have been released,
+and they're perfect for running Paper servers and generating `plugin.yml`.
 
-### Changed
+Rather than maintaining our own implementations, BukkitGradle now leverages jpenilla's work, allowing us to:
+
+1. **Reduce maintenance burden**: By delegating core functionality to actively maintained projects
+2. **Focus on innovation**: Instead of reinventing the wheel, we can add new features
+
+The main goal of BukkitGradle is now to provide nice defaults and a unified API
+that simplifies plugin development by seamlessly integrating these plugins.
+
+### Features
 
 - **Breaking change!**
-  Refactor development server implementation to use [jpenilla/run-task](https://github.com/jpenilla/run-task/) plugin and integrate run-paper for server execution,
+  Use [jpenilla/run-task](https://github.com/jpenilla/run-task/) plugin and integrate run-paper for server execution,
   improving maintainability and compatibility with various server versions.
   - Remove `bukkit.server.coreType` property.
     Spigot is not supported anymore, PaperMC is the only supported server.
     If you need to run other server cores,
     please [file an issue](https://github.com/EndlessCodeGroup/BukkitGradle/issues/new).
 - **Breaking change!**
-  Use [jpenilla/resource-factory](https://github.com/jpenilla/resource-factory) to generate `plugin.yml`.
-  This change comes with some renames:
+  Use [jpenilla/resource-factory](https://github.com/jpenilla/resource-factory) under the hood to generate `plugin.yml`.
+  This change enables full configuration of `plugin.yml` from a build script, but it comes with some renaming:
   - Configuration block `bukkit.meta { ... }` -> `bukkit.plugin { ... }`
   - Property `bukkit.plugin.url` -> `bukkit.plugin.website`
   - Task `:parsePluginMetaFile` -> `:parsePluginYaml`
   - Task `:mergePluginMeta` has been dropped. Use `:mainResourceFactory` instead
   - Package `ru.endlesscode.bukkitgradle.meta` -> `ru.endlesscode.bukkitgradle.plugin`
-- - **Breaking change!** Change API for disabling `plugin.yml` generation:
-  ```diff
-  -bukkit.disableMetaGeneration()
-  +bukkit.generatePluginYaml.set(false)
-  ```
 - **Breaking change!** Don't add repositories implicitly.
   It was impossible to opt out from automatic repositories adding. 
   From now, repositories should be added manually. For example:
@@ -50,13 +49,28 @@
       apiVersion = "1.20.5"
   }
   ```
+- Support setting "api-version" containing a patch version for v1.20.5+
+- Add dependency substitution rules fixing paper groupId and substituting bukkit version.
+  In version catalogs placeholder value `{bukkit.version}` can be used, and it will be replaced with the actual version:
+  ```toml
+  [libraries]
+  paperApi = { module = "io.papermc.paper:paper-api", version = "{bukkit.apiVersion}" }
+  ```
 - Set the default [JVM toolchain](https://docs.gradle.org/current/userguide/toolchains.html) version
   instead of setting JVM target and source compatibility to 1.8.
-  By default, the minimal supported JVM version compatible with the specified `bukkit.server.version` is used.
-- Use lazy API for `bukkit.apiVersion` and `bukkit.generateMeta` properties.
+  By default, the minimal supported JVM version compatible with the specified `bukkit.apiVersion` is used.
 - Accept EULA using CLI parameter `-Dcom.mojang.eula.agree=true` instead of changing `eula.txt`
+
+### Changed
+
 - Change the default value of `bukkit.server.debug` to `false`.
   It is recommended to use IDE facilities to run server with enabled debugging.
+- Change API for disabling `plugin.yml` generation:
+  ```diff
+  -bukkit.disableMetaGeneration()
+  +bukkit.generatePluginYaml.set(false)
+  ```
+- Use lazy API for `bukkit.apiVersion` property.
 
 ### Fixed
 
@@ -66,7 +80,7 @@
 
 ### Housekeeping
 
-- Target JVM 1.8 → 17 
+- Target JVM 1.8 → 17
 - Gradle 7.2 → 8.13
 - Remove old deprecated APIs
 
@@ -152,7 +166,7 @@ It will be parsed from `bukkit.apiVersion` but you can override it with `bukkit.
 ```kotlin
 bukkit {
     apiVersion = "1.16.4" // Inferred api-version is 1.16
-    
+
     meta {
         apiVersion.set("1.13") // But here you can override it
     }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ plugins {
 }
 
 group = "com.example.myplugin"
-description = "My first Bukkit plugin built by Gradle"
+description = "My first Bukkit plugin built with Gradle"
 version = "0.1"
 
 bukkit {
@@ -111,7 +111,7 @@ api-version: 1.21.5
 name: MyPlugin
 version: '0.1'
 main: com.example.myplugin.MyPlugin
-description: My first Bukkit plugin built by Gradle
+description: My first Bukkit plugin built with Gradle
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ Gradle utilities to simplify Bukkit/Spigot plugins writing and debugging.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-#### Features:
+#### Features
 
 - Sets up compiler encoding to UTF-8
-- Sets archivesBaseName to plugin name
-- Supports APIs: Bukkit, CraftBukkit, Spigot, Paper
 - Provides short extension functions to add common repositories and dependencies
 - Generates plugin.yml from Gradle project information
 - Allows running dev server from IDE
@@ -38,7 +36,7 @@ Gradle utilities to simplify Bukkit/Spigot plugins writing and debugging.
 
 ```kotlin
 plugins {
-    id("ru.endlesscode.bukkitgradle") version "0.10.1"
+    id("ru.endlesscode.bukkitgradle") version "1.0.0"
 }
 ```
 
@@ -80,7 +78,7 @@ These values will be used to generate the `plugin.yml` file:
 
 ```kotlin
 plugins {
-    id("ru.endlesscode.bukkitgradle") version "0.10.1"
+    id("ru.endlesscode.bukkitgradle") version "1.0.0"
 }
 
 group = "com.example.myplugin"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=ru.endlesscode
-description=Bukkit Gradle integration plugins
-version=0.11.0-SNAPSHOT
+description=Simple development of Bukkit plugins with Gradle
+version=1.0.0
 org.gradle.jvmargs=-Xmx3G
 org.gradle.parallel=true
 org.gradle.daemon=true


### PR DESCRIPTION
### Pivot!

After a 4-year hiatus in releases, the plugin landscape has evolved significantly.
jpenilla's excellent plugins [run-task](https://github.com/jpenilla/run-task/) and [resource-factory](https://github.com/jpenilla/resource-factory) have been released,
and they're perfect for running Paper servers and generating `plugin.yml`.

Rather than maintaining our own implementations, BukkitGradle now leverages jpenilla's work, allowing us to:

1. **Reduce maintenance burden**: By delegating core functionality to actively maintained projects
2. **Focus on innovation**: Instead of reinventing the wheel, we can add new features

The main goal of BukkitGradle is now to provide nice defaults and a unified API
that simplifies plugin development by seamlessly integrating these plugins.

### Features

- **Breaking change!**
  Use [jpenilla/run-task](https://github.com/jpenilla/run-task/) plugin and integrate run-paper for server execution,
  improving maintainability and compatibility with various server versions.
  - Remove `bukkit.server.coreType` property.
    Spigot is not supported anymore, PaperMC is the only supported server.
    If you need to run other server cores,
    please [file an issue](https://github.com/EndlessCodeGroup/BukkitGradle/issues/new).
- **Breaking change!**
  Use [jpenilla/resource-factory](https://github.com/jpenilla/resource-factory) under the hood to generate `plugin.yml`.
  This change enables full configuration of `plugin.yml` from a build script, but it comes with some renaming:
  - Configuration block `bukkit.meta { ... }` -> `bukkit.plugin { ... }`
  - Property `bukkit.plugin.url` -> `bukkit.plugin.website`
  - Task `:parsePluginMetaFile` -> `:parsePluginYaml`
  - Task `:mergePluginMeta` has been dropped. Use `:mainResourceFactory` instead
  - Package `ru.endlesscode.bukkitgradle.meta` -> `ru.endlesscode.bukkitgradle.plugin`
- **Breaking change!** Don't add repositories implicitly.
  It was impossible to opt out from automatic repositories adding. 
  From now, repositories should be added manually. For example:
  ```kotlin
  repositories {
      mavenCentral()
      papermc()
  }
  ```
- **Breaking change!**
  Don't set default `bukkit.apiVersion`.
  It was implicitly set to `1.16.4` for the sake of simplicity, but in fact it was unobvious behavior.
  Now, `bukkit.apiVersion` should be set explicitly:
  ```kotlin
  bukkit {
      apiVersion = "1.20.5"
  }
  ```
- Support setting "api-version" containing a patch version for v1.20.5+
- Add dependency substitution rules fixing paper groupId and substituting bukkit version.
  In version catalogs placeholder value `{bukkit.version}` can be used, and it will be replaced with the actual version:
  ```toml
  [libraries]
  paperApi = { module = "io.papermc.paper:paper-api", version = "{bukkit.apiVersion}" }
  ```
- Set the default [JVM toolchain](https://docs.gradle.org/current/userguide/toolchains.html) version
  instead of setting JVM target and source compatibility to 1.8.
  By default, the minimal supported JVM version compatible with the specified `bukkit.apiVersion` is used.
- Accept EULA using CLI parameter `-Dcom.mojang.eula.agree=true` instead of changing `eula.txt`

### Changed

- Change the default value of `bukkit.server.debug` to `false`.
  It is recommended to use IDE facilities to run server with enabled debugging.
- Change API for disabling `plugin.yml` generation:
  ```diff
  -bukkit.disableMetaGeneration()
  +bukkit.generatePluginYaml.set(false)
  ```
- Use lazy API for `bukkit.apiVersion` property.

### Fixed

- Fix PaperMC repository URL
- Fix group ID for PaperMC 1.17+
- Fix compatibility with new versions of Shadow plugin

### Housekeeping

- Target JVM 1.8 → 17
- Gradle 7.2 → 8.13
- Remove old deprecated APIs